### PR TITLE
Fix EF migration base path

### DIFF
--- a/OnlineQuiz.Repository.SqlServer/OnlineQuizDbContextFactory.cs
+++ b/OnlineQuiz.Repository.SqlServer/OnlineQuizDbContextFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
 using OnlineQuiz.Domain.Entities;
+using System.IO;
 
 namespace OnlineQuiz.Repository.SqlServer
 {
@@ -9,8 +10,9 @@ namespace OnlineQuiz.Repository.SqlServer
     {
         public OnlineQuizDbContext CreateDbContext(string[] args)
         {
+            var basePath = Path.GetDirectoryName(typeof(OnlineQuizDbContextFactory).Assembly.Location);
             var configuration = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
+                .SetBasePath(basePath!)
                 .AddJsonFile("appsettings.json", optional: false)
                 .Build();
 


### PR DESCRIPTION
## Summary
- locate `appsettings.json` correctly during design-time DbContext creation
- add missing `System.IO` import

## Testing
- `dotnet ef migrations add TestMigration --project OnlineQuiz.Repository.SqlServer --startup-project OnlineQuiz -- --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3588d34483338c02c9851be45d3c