### PR TITLE
Add auth services interface and update DI

### DIFF
--- a/OnlineQuiz.Application/Services/Interfaces/IAuthServices.cs
+++ b/OnlineQuiz.Application/Services/Interfaces/IAuthServices.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Identity;
+using OnlineQuiz.Application.DTOs;
+
+namespace OnlineQuiz.Application.Services.Interfaces
+{
+    public interface IAuthServices
+    {
+        Task<LoginResult> LoginAsync(SignInDto signInDto);
+        Task<IdentityResult> RegisterAsync(SignUpDto signUpDto);
+    }
+}

--- a/OnlineQuiz.Domain/Interfaces/IAuthService.cs
+++ b/OnlineQuiz.Domain/Interfaces/IAuthService.cs
@@ -1,8 +1,0 @@
-﻿namespace OnlineQuiz.Domain.Interfaces
-{
-    public interface IAuthService
-    {
-        public async Task<LoginResult> LoginAsync(SignInDto signInDto);
-        public async Task<IdentityResult> RegisterAsync(SignUpDto signUpDto);
-    }
-}

--- a/OnlineQuiz/Program.cs
+++ b/OnlineQuiz/Program.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using OnlineQuiz.Domain.Entities;
 using OnlineQuiz.Infrastructure.Data;
+using OnlineQuiz.Application.Services.Interfaces;
+using OnlineQuiz.Application.Services;
 using System.IdentityModel.Tokens.Jwt;
 
 
@@ -73,7 +75,7 @@ namespace OnlineQuiz
 
             builder.Services.AddAutoMapper(typeof(OnlineQuiz.Application.Mappings.AutoMapperProfile));
 
-            builder.Services.AddScoped<OnlineQuiz.Application.Services.Interfaces.IAuthServices, OnlineQuiz.Application.Services.AuthServices>();
+            builder.Services.AddScoped<IAuthServices, AuthServices>();
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.


### PR DESCRIPTION
## Summary
- create `IAuthServices` interface in `Application.Services.Interfaces`
- remove old domain interface
- update Program.cs DI to use the new interface

## Testing
- `dotnet build OnlineQuiz.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d931c4f688333a21147af129bfded